### PR TITLE
Nerf bats

### DIFF
--- a/code/game/objects/items/weapons/material/bats.dm
+++ b/code/game/objects/items/weapons/material/bats.dm
@@ -10,8 +10,8 @@
 	attack_verb = list("smashed", "beaten", "slammed", "smacked", "struck", "battered", "bonked")
 	sound_hit = 'sound/weapons/genhit3.ogg'
 	default_material = MATERIAL_MAPLE
-	force_divisor = 1.1           // 22 when wielded with weight 20 (steel)
-	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
+	force_divisor = 0.5          // 10 when wielded with weight 20 (steel)
+	unwielded_force_divisor = 0.3 // 6 when unwielded based on above.
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = -10
 


### PR DESCRIPTION
Bats, similar to swords, escaped the Persistence balancing wave. A tungsten bat is capable of dealing something approaching 35 damage, and a lead bat is even worse at 44. This puts the bats more in line with swords given weighty materials.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
